### PR TITLE
Update brfs version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "atomify-css": "0.0.x"
   },
   "peerDependencies": {
-    "brfs": "0.0.6",
+    "brfs": "~0.0.8",
     "handlebars-runtime": "~1.0.12",
     "hbsfy": "~0.1.5"
   }


### PR DESCRIPTION
Without ~ there is a conflict between atomify ("brfs": "0.0.6") and atomify-js ("brfs": "~0.0.8") when installing atomify-cli.
