### PR TITLE
Remove unneeded peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,5 @@
   "dependencies": {
     "atomify-js": "~0.0.10",
     "atomify-css": "~0.0.6"
-  },
-  "peerDependencies": {
-    "brfs": "~0.0.9",
-    "handlebars-runtime": "~1.0.12",
-    "hbsfy": "~1.3.1"
   }
 }


### PR DESCRIPTION
I don't think `atomify` needs to know anything about these since `atomify-js` includes them on its own, and `atomify` only directly references `atomify-js` and `atomify-css`
