### PR TITLE
atomify --serve FTMFW

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,6 +2,7 @@ var js = require('atomify-js')
   , css = require('atomify-css')
   , fs = require('fs')
   , writer = require('write-to-path')
+  , server = require('./server')
 
 module.exports = function (args) {
   if (args._[0] === 'help' || args.help) {
@@ -21,7 +22,7 @@ module.exports = function (args) {
     args.css.plugins = args.css.p || args.css.plugins
     args.css.compress = args.css.c || args.css.compress
 
-    css(args.css, writer(args.css.output, args.css))
+    if (args.css.output) css(args.css, writer(args.css.output, args.css))
   }
 
   if (args.js) {
@@ -30,8 +31,10 @@ module.exports = function (args) {
     args.js.watch = args.js.w || args.js.watch
     args.js.transforms = args.js.t || args.js.transform
 
-    js(args.js, writer(args.js.output, args.js))
+    if (args.js.output) js(args.js, writer(args.js.output, args.js))
   }
+
+  if (args.serve) server(args)
 }
 
 function parseArgs (ext, child, parent) {
@@ -40,13 +43,19 @@ function parseArgs (ext, child, parent) {
   if (typeof child.e === 'string') child.entry = child.e // -j [ -e entry.js ]
   if (Array.isArray(child.e)) child.entries = child.e // -j [ -e entry.js -e other.js ]
 
+  if (child.entry.indexOf(':') > 0) {
+    var pieces = child.entry.split(':')
+    child.entry = pieces[0]
+    child.alias = pieces[1]
+  }
+
   child.debug = child.d || child.debug || parent.debug
 
   child.output = child.o || child.output
   if (child._ && child._.length === 2) child.output = child._[1] // -j [ entry.js bundle.js ]
   if (!child.output && parent.output) child.output = parent.output.indexOf(ext) > 1 ? parent.output : parent.output + '.' + ext
 
-  if (!child.output) {
+  if (!child.output && !parent.serve) {
     console.error('No output path provided for ' + ext.toUpperCase() + ' bundle!')
     process.exit(1)
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,0 +1,41 @@
+var st = require('st')
+  , http = require('http')
+  , js = require('atomify-js')
+  , css = require('atomify-css')
+  , open = require('open')
+
+module.exports = function (args) {
+
+  var mount = st(args.serve.st || process.cwd())
+    , port = args.serve.port || 1337
+    , launch = args.serve.open
+    , path = args.serve.path || ''
+    , url = args.serve.url || 'http://localhost:' + port + path
+
+  http.createServer(function(req, res) {
+
+    switch (req.url) {
+      case args.js.alias || args.js.entry:
+        js(args.js, responder('javascript', res))
+        break
+
+      case args.css.alias || args.css.entry:
+        css(args.css, responder('css', res))
+        break
+
+      default:
+        mount(req, res)
+        break
+    }
+
+  }).listen(port)
+
+  if (launch) open(url)
+}
+
+function responder (type, res) {
+  return function (err, src) {
+    if (!res.headersSent) res.setHeader('Content-Type', 'text/' + type)
+    res.end(src)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "atomify-js": "~0.6.0",
     "atomify-css": "~0.5.0",
     "subarg": "0.0.1",
-    "write-to-path": "~0.1.0"
+    "write-to-path": "~0.1.0",
+    "st": "~0.3.1",
+    "open": "0.0.4"
   },
   "devDependencies": {
     "tape": "~2.4.2"


### PR DESCRIPTION
This was sort of hilariously easy. Was using this as an npm script in my project:

`atomify -j [ index.js:/bundle.js -w -d ] -c [ src/index.css:/bundle.css ] --serve [ --path /example/index.html --open ]`

Other flags supported in `--serve`'s subarg block: 
- `--st` object that will be passed directly to `st` for configuration, defaults to `process.cwd()`.
- `--port` Duh.
- `--path` Path that will be appended to localhost:port when opening
- `--url` Full url to be opened instead of localhost:port+path
- `--open` If provided, default browser will be opened when starting the server

Needs plenty more testing and verification before it's merged but pretty sure this is 98% of what we want. :)
