### PR TITLE
If no args are passed, read config from atomify field of package.json

### DIFF
--- a/bin/atomify.js
+++ b/bin/atomify.js
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
-var cli = require('../lib/cli')
-  , argv = require('subarg')(process.argv.slice(2), {
+var path = require('path')
+  , cli = require('../lib/cli')
+  , args = process.argv.slice(2)
+  , argv = require('subarg')(args, {
     alias: {
       j: 'js'
       , c: 'css'
@@ -12,5 +14,7 @@ var cli = require('../lib/cli')
       , s: 'server'
     }
   })
+
+if (!args.length) argv = require(path.join(process.cwd(), 'package.json')).atomify;
 
 cli(argv)


### PR DESCRIPTION
My scripts fields were getting long, so was thinking it would be nice to configure things elsewhere. As you can see, it's not exactly a big change. :)

``` json
"atomify": {
  "js": {
    "entry": "example/index.js",
    "w": true,
    "d": true
  },
  "css": "index.css:/example/bundle.css",
  "server": {
    "path": "/example/index.html",
    "open": true
  }
}
```
