### PR TITLE
Fix conflicting pathVarName

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -26,13 +26,13 @@ module.exports = function (args) {
   var mount = st(args.server.st || { path: process.cwd(), cache: false })
     , parsedUrl = url.parse(args.server.url)
     , port = args.server.port || parsedUrl.port
-    , path = args.server.path || parsedUrl.path
+    , serverPath = args.server.path || parsedUrl.path
     , lr = args.server.lr || args.server.l
     , launch = args.server.open || args.server.o
 
   if (args.server.sync || args.server.s) lr = {sync: true}
 
-  if (path.charAt(0) !== '/') path = '/' + path
+  if (serverPath.charAt(0) !== '/') serverPath = '/' + serverPath
   if (!args.js) args.js = {}
   if (!args.js.alias) args.js.alias = '/' + args.js.entry
   if (!args.css) args.css = {}
@@ -102,7 +102,7 @@ module.exports = function (args) {
   console.log(('Atomify server listening on port ' + port).grey)
   console.log('')
 
-  if (launch) open(baseUrl + ':' + port + path)
+  if (launch) open(baseUrl + ':' + port + serverPath)
 }
 
 function responder (type, res) {


### PR DESCRIPTION
Previously, the `path` var would conflict with the node.js builtin `path` lib.
