### PR TITLE
auto import css

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,21 +1,63 @@
 var js = require('atomify-js')
   , css = require('atomify-css')
   , server = require('./lib/server')
+  , fs = require('fs')
+  , path = require('path')
 
 module.exports = atomify
 
 function atomify (opts, cb) {
+
   if (opts.assets && opts.css) opts.css.assets = opts.assets
   if (opts.assets && opts.js) opts.js.assets = opts.assets
 
   if (opts.server) return server(opts)
-  if (opts.css) css(opts.css, callback(cb, 'css'))
-  if (opts.js) js(opts.js, callback(cb, 'js'))
-}
 
-atomify.js = js
-atomify.css = css
-atomify.server = server
+  if (opts.js) var bundle = js(opts.js, callback(cb, 'js'))
+
+  if( opts.js && opts.css && (opts.css === "auto" || (typeof opts.css === "object" && opts.css.entry === "auto" )) ){
+    var tempcss = path.join( process.cwd(), '_tempCss.css' )
+    var total = ""
+    var _cb = cb
+
+    cb = function(err, src, type){
+      fs.unlinkSync( tempcss )
+      if(typeof _cb === 'function'){
+        _cb(err, src, type);
+      }
+    }
+
+    atomify.js.emitter.on('package', function(pkg){
+      var pkg_dir = path.dirname(pkg),
+          pkg_path = path.join(pkg_dir, 'package.json');
+
+      if(fs.existsSync(pkg_path) ){
+        var pkg_obj = JSON.parse(fs.readFileSync(pkg_path)),
+            pkg_entry;
+        if(pkg_obj && pkg_obj.style ){
+          if( typeof pkg_obj.style !== "string" 
+            || !fs.existsSync( pkg_entry = path.resolve( pkg_dir, pkg_obj.style )) ) return
+          total += "@import " + JSON.stringify( pkg_entry ) + ";";
+        }else if ( fs.existsSync( pkg_entry = path.join( pkg_dir, "index.css" ) ) ) {
+          total += "@import " + JSON.stringify( pkg_entry ) + ";";
+        }
+      }
+    })
+
+    bundle.on('end', function(){
+      fs.writeFileSync( tempcss, total )
+      if(typeof opts.css === "string")
+        opts.css = tempcss;
+      else
+        opts.css.entry = tempcss;
+      css(opts.css, callback(cb, 'css'))
+    })
+
+  } else if (opts.css){
+    css(opts.css, callback(cb, 'css'))
+  }
+
+}
 
 function callback (cb, type) {
   if (!cb) return null
@@ -24,3 +66,7 @@ function callback (cb, type) {
     cb(err, src, type)
   }
 }
+
+atomify.js = js
+atomify.css = css
+atomify.server = server

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -5,6 +5,7 @@ var js = require('atomify-js')
   , writer = require('write-to-path')
   , server = require('./server')
   , pkgCfg = path.join(process.cwd(), 'package.json')
+  , atomify = require('../')
 
 pkgCfg = fs.existsSync(pkgCfg) && require(pkgCfg).atomify ? require(pkgCfg).atomify : {}
 
@@ -34,8 +35,6 @@ module.exports = function (args) {
     args.css.variables = args.css.v || args.css.variables
     args.css.plugins = args.css.p || args.css.plugins
     args.css.compress = args.css.c || args.css.compress
-
-    if (args.css.output) css(args.css, writer(args.css.output, args.css))
   }
 
   if (args.js) {
@@ -43,8 +42,13 @@ module.exports = function (args) {
 
     args.js.watch = args.js.w || args.js.watch
     args.js.transforms = args.js.t || args.js.transform
+  }
 
-    if (args.js.output) js(args.js, writer(args.js.output, args.js))
+  if(args.js.output || args.css.output){
+    atomify({ 
+      css: args.css.output ? args.css : undefined,
+      js: args.js.output ? args.js : undefined 
+    })
   }
 
   if (args.server) server(args)

--- a/test/fixtures/js/bundle-auto.js
+++ b/test/fixtures/js/bundle-auto.js
@@ -1,0 +1,7 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+var dep = require('./pkg');
+},{"./pkg":2}],2:[function(require,module,exports){
+module.exports = require('../pkg2');
+},{"../pkg2":3}],3:[function(require,module,exports){
+module.exports = 'I am a dep';
+},{}]},{},[1])

--- a/test/fixtures/js/entry-auto.js
+++ b/test/fixtures/js/entry-auto.js
@@ -1,0 +1,1 @@
+var dep = require('./pkg');

--- a/test/fixtures/js/pkg/index.js
+++ b/test/fixtures/js/pkg/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../pkg2');

--- a/test/fixtures/js/pkg/package.json
+++ b/test/fixtures/js/pkg/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "pkg",
+  "main": "index.js"
+}

--- a/test/fixtures/js/pkg2/index.js
+++ b/test/fixtures/js/pkg2/index.js
@@ -1,0 +1,1 @@
+module.exports = 'I am a dep';

--- a/test/fixtures/js/pkg2/package.json
+++ b/test/fixtures/js/pkg2/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "pkg2",
+  "main": "index.js",
+  "style": "../../css/entry.css"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,19 @@ test('js and css', function (t) {
   })
 })
 
+test('js and css, auto import', function (t) {
+  t.plan(2)
+
+  atomify({js: jsf + 'entry-auto.js', css: 'auto'}, function (err, src, type) {
+    if (src === read(jsf + 'bundle-auto.js')) {
+      t.equal(type, 'js')
+    }    
+    if (src === read(cssf + 'bundle.css')) {
+      t.equal(type, 'css')
+    }
+  })
+})
+
 test('js output does not prevent callback', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
added test and functionality for auto import

updated cli to handle this functionality as well

PLEASE NOTE:  you must add the following to atomify-js at line 62 in the node_modules folder!!! 

``` javascript
  b.on('package', function(pkg){
    emitter.emit('package', pkg)
  })
```

breaks no tests (that werent already broken) ... let me know what you think or if you need more in depth examples!

yes this adds a bit to your atomify code, it isnt very pretty, but it can be optimized or made prettier or whatever... just would LOVE to have this functionality!!!

in a nutshell it listens for package events from browserify, and then looks for each packages style property or index.css which (if existing) are compiled as @imports into a temporary css file, then runs that temp file through atomify-css and deletes it after bundling.  this could be more elegant by accumulating the @imports as a string and run them directly into atomify-css but it doesnt appear this is possible, it requires a file ATM
