### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "subarg": "^1.0.0",
     "through": "^2.3.6",
     "tiny-lr-fork": "0.0.5",
-    "write-to-path": "~0.1.0"
+    "write-to-path": "^1.1.0"
   },
   "devDependencies": {
     "tape": "~2.5.0",


### PR DESCRIPTION
Gets all of our deps up-to-date except gaze b/c it breaks in node 0.11. No breaking changes here.

Issue for gaze dep: https://github.com/atomify/atomify/issues/59

Fixes #52 
