### PR TITLE
So much change! So much perf!

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can provide server-specific options in this field.
 
  * sync: Use BrowserSync. Aliased as `s`. If provided as an object will be used as the [ghostMode](https://github.com/shakyShane/browser-sync/wiki/options#ghostmode) option for BrowserSync.
  * port: Port for BrowserSync server to run on. Default: 3000
- * patterns: Globbing patterns to pass to [gaze](https://www.npmjs.org/package/gaze) for watching. Default: ['\*.html', '\*.css'] relative to process.cwd() as well as all files in the dependency graph of your JS and CSS bundles.
+ * patterns: Globbing patterns to pass to [browsersync](https://www.npmjs.org/package/browser-sync) for watching. Default: `['**.html']` relative to `process.cwd()` as well as all files in the dependency graph of your JS and CSS bundles.
  * quiet: Suppress file change notifications on the command line. Default: false
  * verbose: Log BrowserSync's debugInfo to the console. Default: false
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,29 @@ You can provide server-specific options in this field.
 
 **opts.server.st** - Options to pass to [st](https://www.npmjs.org/package/st) static file server, which is what serves all non-entry/alias requests.
 
+**opts.server.html** - Override the default HTML served at `/default`. Pass either a filepath or a function.
+
+If you pass a function, you'll be passed one options argument with the urls to the bundled JS and CSS. You should insert those into your HTML, and return a string.
+
+```js
+{
+  server: {
+    html: function html (paths, done){
+      // it's important to include the body tags so that the livereload snippet from browsersync can be inserted
+      var html = '<body>'
+        + '<link rel="stylesheet" href="' + paths.css + '">'
+        + '<script src="' + paths.js + '"></script>'
+        + '</body>'
+
+      // you can return an error if something went wrong
+      done(null, html)
+    }
+  }
+}
+```
+
+If you pass a filepath, the bundled JS and CSS will automatically be inserted at the bottom of your file. However, you can place the strings `__ATOMIFY_CSS__` and `__ATOMIFY_JS__` when you want the relevant paths inserted to override this behavior.
+
 ## package.json config
 
 In order to support atomify turtles all the way down, you can also specify your configuration in package.json. Simply recreate an `opts` object structure in JSON with atomify as the key. (Omit output properties if not a top level package.)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Atomic web development - Combining the power of npm, Browserify, Rework and more
 
 ## Description
 
-Atomify provides a centralized point of access to [atomify-js](http://github.com/techwraith/atomify-js) and [atomify-css](http://github.com/techwraith/atomify-css) both in code and on the command line. It also offers a server with live-reload and on-the-fly bundling support to make development a breeze.
+Atomify provides a centralized point of access to [atomify-js](http://github.com/atomify/atomify-js) and [atomify-css](http://github.com/atomify/atomify-css) both in code and on the command line. It also offers a server with live-reload and on-the-fly bundling support to make development a breeze.
 
 ## Examples
 
@@ -19,9 +19,9 @@ Just like its constituent pieces, atomify is a function that takes an `opts` obj
 
 ### opts
 
-**opts.js** - Options to be passed to [atomify-js](https://github.com/techwraith/atomify-js#opts)
+**opts.js** - Options to be passed to [atomify-js](https://github.com/atomify/atomify-js#opts)
 
-**opts.css** - Options to be passed to [atomify-css](https://github.com/techwraith/atomify-css#opts)
+**opts.css** - Options to be passed to [atomify-css](https://github.com/atomify/atomify-css#opts)
 
 **opts.assets** - Used to configure `opts.js.assets` and `opts.css.assets` simultaneously (and identically). See links above.
 
@@ -92,7 +92,7 @@ You can provide server-specific options in this field.
 
 **opts.server.lr** - Enables live-reload support by injecting the live-reload script into any HTML pages served. Supports the following sub-properties.
 
- * sync: Use BrowserSync. Aliased as s. If provided as an object will be used as the [ghostMode](https://github.com/shakyShane/browser-sync/wiki/options#ghostmode) option for BrowserSync.
+ * sync: Use BrowserSync. Aliased as `s`. If provided as an object will be used as the [ghostMode](https://github.com/shakyShane/browser-sync/wiki/options#ghostmode) option for BrowserSync.
  * port: Port for BrowserSync server to run on. Default: 3000
  * patterns: Globbing patterns to pass to [gaze](https://www.npmjs.org/package/gaze) for watching. Default: ['\*.html', '\*.css'] relative to process.cwd() as well as all files in the dependency graph of your JS and CSS bundles.
  * quiet: Suppress file change notifications on the command line. Default: false
@@ -151,7 +151,7 @@ In order to support atomify turtles all the way down, you can also specify your 
 }
 ```
 
-For detailed information on configuring Rework plugins in package.json see the [relevant section](https://github.com/Techwraith/atomify-css#packagejson-config) of the atomify-css README.
+For detailed information on configuring Rework plugins in package.json see the [relevant section](https://github.com/atomify/atomify-css#packagejson-config) of the atomify-css README.
 
 ## CLI
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,8 @@ var st = require('st')
   , gaze = require('gaze')
   , browserSync = require('browser-sync')
   , defaultBundlePath = path.join(__dirname, '_bundle.js')
+  , JS_REPLACE = '__ATOMIFY_JS__'
+  , CSS_REPLACE = '__ATOMIFY_CSS__'
   , cwd = process.cwd()
   , internals = {}
   , baseUrl
@@ -51,7 +53,7 @@ internals.watchCSSimportsAndAssets = function watchCSSimportsAndAssets (args) {
   })
 }
 
-internals.serveDefaultPage = function serveDefaultPage (res, args) {
+internals.getDefaultHTML = function getDefaultHTML (args){
   var src = '<!doctype html><html><head>'
   src += '<meta charset="utf-8">'
   src += '<meta http-equiv="X-UA-Compatible" content="IE=edge">'
@@ -65,9 +67,61 @@ internals.serveDefaultPage = function serveDefaultPage (res, args) {
   src = src.replace('JS', args.js.alias)
   src = src.replace('CSS', args.css.alias)
 
-  res.setHeader('Content-Type', 'text/html')
+  return src
+}
 
-  res.end(src)
+internals.customDefaultHTML = ''
+
+internals.setCustomDefaultHTML = function setCustomDefaultHTML (file, args){
+  var html = fs.readFileSync(file, {encoding: 'utf8'})
+    , shouldReplaceJS = html.indexOf(JS_REPLACE) > -1
+    , shouldReplaceCSS = html.indexOf(CSS_REPLACE) > -1
+
+  if (shouldReplaceCSS) html.replace(CSS_REPLACE, args.css.alias)
+  else html += '<link rel="stylesheet" href="' + args.css.alias + '">'
+
+  if (shouldReplaceJS) html.replace(JS_REPLACE, args.js.alias)
+  else html += '<script src="' + args.js.alias + '"></script>'
+
+  internals.customDefaultHTML = html
+
+  return internals.customDefaultHTML
+}
+
+internals.getCustomDefaultHTML = function getCustomDefaultHTML (args, callback){
+  var html = args.server.html
+    , htmlIsFile = typeof html === 'string'
+
+  if (!html) callback(null, null)
+
+  // if the html arg is a string, assume it's a file name
+  // if we've already cached this file, don't go read it again
+  if (htmlIsFile && html !== internals.customDefaultHTML) {
+    callback(null, internals.setCustomDefaultHTML(html, args))
+  }
+  else if (htmlIsFile){
+    callback(null, internals.customDefaultHTML)
+  }
+  // if the html arg isn't a string, it should be a function that returns html
+  else {
+    html({js: args.js.alias, css: args.css.alias}, callback)
+  }
+}
+
+internals.serveDefaultPage = function serveDefaultPage (res, args) {
+  internals.getCustomDefaultHTML(args, function gotCustomDefaultHTML (err, html){
+    var src = html || internals.getDefaultHTML(args)
+
+    res.setHeader('Content-Type', 'text/html')
+
+    if (err) {
+      res.statusCode = 500
+      res.end(err.message || err)
+    }
+    else {
+      res.end(src)
+    }
+  })
 }
 
 internals.parseSyncOptions = function parseSyncOptions (opts) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,15 +12,13 @@ var st = require('st')
   , lessFiles = require('atomify-css/less')
   , open = require('open')
   , gaze = require('gaze')
-  , browserSync = require('browser-sync')
+  , browserSync = require('browser-sync').create()
   , defaultBundlePath = path.join(__dirname, '_bundle.js')
   , JS_REPLACE = '__ATOMIFY_JS__'
   , CSS_REPLACE = '__ATOMIFY_CSS__'
   , cwd = process.cwd()
   , internals = {}
   , baseUrl
-
-require('colors')
 
 internals.watchCSSimportsAndAssets = function watchCSSimportsAndAssets (args) {
   var watchlist = []
@@ -52,6 +50,7 @@ internals.watchCSSimportsAndAssets = function watchCSSimportsAndAssets (args) {
     })
   })
 }
+  , bs
 
 internals.getDefaultHTML = function getDefaultHTML (args){
   var src = '<!doctype html><html><head>'
@@ -144,10 +143,10 @@ internals.getNormalizedPath = function getNormalizedPath (pathStr) {
 
 internals.responder = function responder (type, res) {
   return function response (err, src) {
-    if (err) console.error(err)
+    if (err) bs.logger.error(err)
 
     if (!res.headersSent) res.setHeader('Content-Type', 'text/' + type)
-    res.end(src)
+    res.end(src || err)
   }
 }
 
@@ -183,8 +182,6 @@ internals.startFileWatch = function startFileWatch (lr, args) {
 module.exports = function server (args) {
   // sometimes the hostname has a '.local' on it, sometimes it doesn't
   var hostname = args.server.hostname || args.server.h ? os.hostname().replace(/\.local$/, '') + '.local' : 'localhost'
-
-  console.info('')
 
   args.server.url = args.server.url || 'http://' + hostname + ':1337/default'
 
@@ -234,20 +231,24 @@ module.exports = function server (args) {
     }
 
     internals.startFileWatch(lr, args)
-    console.info(('Live reload server listening on port ' + lr.port).grey)
 
-    var bs = browserSync({
-      proxy: parsedUrl.hostname + ':' + port
+    bs = browserSync.init({
+      proxy: {
+        target: parsedUrl.hostname + ':' + port
+      }
       , port: lr.port
       , injectChanges: true
       , ghostMode: lr.sync
-      , notify: !!lr.sync
+      , notify: !!lr.quiet
       , logSnippet: false
       , open: false
       , logLevel: lr.verbose ? 'debug' : 'info'
+      , logFileChanges: !!lr.quiet
+      , logConnections: !!lr.quiet
       // don't minify for speed!
       , minify: false
       , startPath: '/default'
+      , logPrefix: 'atomify'
     })
 
     // listen for initial bundle completion before opening
@@ -287,9 +288,6 @@ module.exports = function server (args) {
       break
     }
   }).listen(port)
-
-  console.info(('Atomify server listening on port ' + port).grey)
-  console.info('')
 
   // if live reload is enabled we open after initial bundling
   if (launch && !lr) open(baseUrl + ':' + port + serverPath)

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,6 @@ var st = require('st')
   , cssFiles = require('atomify-css/css')
   , lessFiles = require('atomify-css/less')
   , open = require('open')
-  , gaze = require('gaze')
   , browserSync = require('browser-sync').create()
   , defaultBundlePath = path.join(__dirname, '_bundle.js')
   , JS_REPLACE = '__ATOMIFY_JS__'
@@ -19,37 +18,6 @@ var st = require('st')
   , cwd = process.cwd()
   , internals = {}
   , baseUrl
-
-internals.watchCSSimportsAndAssets = function watchCSSimportsAndAssets (args) {
-  var watchlist = []
-    , watchpaths
-    , listname
-    , pathlist
-    , filename
-    , gazeCSS
-
-  delete args.resourcepaths.jsEntry
-  watchpaths = args.resourcepaths
-
-  for (listname in watchpaths) {
-    if (watchpaths.hasOwnProperty(listname)){
-      pathlist = watchpaths[listname]
-      for (filename in pathlist) {
-        if (pathlist.hasOwnProperty(filename)){
-          watchlist.push(pathlist[filename])
-        }
-      }
-    }
-  }
-
-  gazeCSS = new gaze.Gaze(watchlist)
-  gazeCSS.on('changed', function onCSSChanged (filepath) {
-    console.info(filepath, ' changed'.grey)
-    css(args.css, function cssCompiled () {
-      console.info('css bundle updated'.grey)
-    })
-  })
-}
   , bs
 
 internals.getDefaultHTML = function getDefaultHTML (args){
@@ -151,41 +119,44 @@ internals.responder = function responder (type, res) {
 }
 
 internals.startFileWatch = function startFileWatch (lr, args) {
-  var onFile = function onFile (filename){
-    this.add(filename)
+  var watchedFiles = []
+    , addFile = function addFile (file){
+      if (watchedFiles.indexOf(file) < 0){
+        watchedFiles.push(file)
+        browserSync.watch(file).on('change', function onCSSChanged (){
+          browserSync.reload(args.css.alias)
+        })
+      }
+    }
+
+  if (!lr.quiet) {
+    js.emitter.on('changed', function onJsChanged (filepath) {
+      bs.logger.info('{cyan:File changed: {magenta:%s', path.relative(cwd, filepath))
+      browserSync.notify('Compiling, please wait!')
+    })
   }
 
-  gaze(lr.patterns, function livereloadPatternsWatched () {
-    // add each file in dependency tree to watch list
-    cssFiles.emitter.on('file', onFile.bind(this))
-
-    lessFiles.emitter.on('file', onFile.bind(this))
-
-    this.on('changed', function onFileChanged (filepath){
-      var ext = path.extname(filepath)
-        , relativePath = path.relative(cwd, filepath)
-
-      // watchify will take care of it's own logging
-      if (!lr.quiet && filepath !== defaultBundlePath && filepath !== '.js') {
-        console.info(relativePath, 'changed'.grey)
-      }
-      // inject the css changes
-      if (ext === '.css' || ext === '.less'){
-        browserSync.notify('compiling css…')
-        browserSync.reload(args.css.alias)
-      }
-    })
+  js.emitter.on('bundle', function onJSBundled (time) {
+    if (!lr.quiet) {
+      bs.logger.info('{grey:Bundle updated in {magenta:%s', time + 'ms')
+    }
+    // for JS, just reload the whole page
+    browserSync.reload()
   })
 
-  if (args.css && args.css.watch) internals.watchCSSimportsAndAssets(args)
+  cssFiles.emitter.on('file', addFile)
+  lessFiles.emitter.on('file', addFile)
+  addFile(args.css.entry)
 }
+
 module.exports = function server (args) {
   // sometimes the hostname has a '.local' on it, sometimes it doesn't
   var hostname = args.server.hostname || args.server.h ? os.hostname().replace(/\.local$/, '') + '.local' : 'localhost'
 
   args.server.url = args.server.url || 'http://' + hostname + ':1337/default'
 
-  var mount = st(args.server.st || {path: cwd, cache: false})
+  var stOptions = args.server.st || {path: cwd, cache: false}
+    , mount = st(stOptions)
     , parsedUrl = url.parse(args.server.url)
     , port = args.server.port || parsedUrl.port
     , serverPath = internals.getNormalizedPath(args.server.path || parsedUrl.path)
@@ -195,6 +166,8 @@ module.exports = function server (args) {
 
   if (args.server.sync || args.server.s) lr = {sync: true}
 
+  args.servePath = stOptions.path
+
   // the router checks these, so they have to exist
   args.js = args.js || {}
   args.js.alias = internals.getNormalizedPath(args.js.alias || args.js.entry)
@@ -203,25 +176,25 @@ module.exports = function server (args) {
 
   baseUrl = parsedUrl.protocol + '//' + parsedUrl.hostname
 
+  // cache the browserify and watchify instances
+  js.emitter.on('browserify', function storeBrowserifyInstace (b){
+    internals.browserify = b
+  })
+  js.emitter.on('watchify', function storeWatchifyInstance (w){
+    internals.watchify = w
+  })
+
   if (lr) {
     // if live reloading, use watchify
     args.js.watch = true
     args.js.output = args.js.output || defaultBundlePath
 
-    if (!lr.quiet) {
-      js.emitter.on('changed', function onJsChanged (filepath) {
-        console.info(path.relative(cwd, filepath), 'changed'.grey)
-        browserSync.notify('Compiling, please wait!')
-      })
-
-      js.emitter.on('bundle', function onJSBundled (time) {
-        console.info(('bundle updated in ' + time + 'ms').grey)
-        browserSync.reload()
-      })
-    }
-
     lr = typeof lr === 'boolean' ? {} : lr
-    lr.patterns = lr.patterns ? lr.patterns.concat(args.js.output) : ['*.html', '*.css', args.js.output, args.css.output]
+    lr.patterns = lr.patterns
+      ? lr.patterns
+      : [path.join(args.servePath, '**/*.html')]
+
+    if (args.css.output) lr.patterns.push(args.css.output)
 
     lr.port = lr.port || 3000
     lr.sync = internals.parseSyncOptions(lr.sync || lr.s)
@@ -229,8 +202,6 @@ module.exports = function server (args) {
     if (port >= lr.port && port <= lr.port + 2) {
       throw new Error('Ports ' + lr.port + ' through ' + (lr.port + 2) + 'in use for Live Reload')
     }
-
-    internals.startFileWatch(lr, args)
 
     bs = browserSync.init({
       proxy: {
@@ -249,7 +220,17 @@ module.exports = function server (args) {
       , minify: false
       , startPath: '/default'
       , logPrefix: 'atomify'
+      , files: lr.patterns.map(function doNotWatchNodeModules (match){
+        return {
+          match: match
+          , options: {
+            ignored: /node_modules/
+          }
+        }
+      })
     })
+
+    internals.startFileWatch(lr, args)
 
     // listen for initial bundle completion before opening
     js(args.js).on('end', function onJSBundled (){

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "atomify-css": "^3.2.1",
     "atomify-js": "^4.0.0",
-    "gaze": "~0.5.1",
     "browser-sync": "^2.6.4",
     "open": "0.0.5",
     "st": "^0.5.2",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,8 @@
   "dependencies": {
     "atomify-css": "^3.2.1",
     "atomify-js": "^4.0.0",
-    "browser-sync": "^1.9.1",
-    "colors": "^1.0.3",
     "gaze": "~0.5.1",
+    "browser-sync": "^2.6.4",
     "open": "0.0.5",
     "st": "^0.5.2",
     "subarg": "^1.0.0",


### PR DESCRIPTION
* dramatic reduction of resources by not watching node_modules
* dramatic speed up of watching by using chokidar instead of gaze which gets us native OS FS events were possible
* no longer running three file watchers, sometimes with overlapping files. We should have a much smaller memory and CPU footprint.
* enables setting the HTML that will be served at `/default` by either file or function. Super useful if you want to server-render.
* unifed logging. It's all pretty now.

Breaking changes:
* we no longer watch all css files under the cwd. Only the entry file and it's dependencies
* I removed a bunch of code added by @serapath in #46. @serapath if you can try this branch and confirm for me that nothing is broken? Fortunately, the APIs that were removed are undocumented.