### PR TITLE
Removed resourcepaths leftover which causes errors when using less

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -36,11 +36,8 @@ module.exports = function (args) {
     args.css.compress = args.css.c || args.css.compress
 
     if (args.css.output) {
-      css(args.css, function doWatchWriteServerstart(err, src, resourcepaths) {
+      css(args.css, function doWatchWriteServerstart(err, src) {
         if (err) console.error(err)
-        resourcepaths.cssEntry  = [path.join(process.cwd(), args.css.entry)]
-        resourcepaths.jsEntry   = [path.join(process.cwd(), args.js.entry)]
-        args.resourcepaths = resourcepaths
         if (args.server) server(args)
       });
     }


### PR DESCRIPTION
I wasn't able to use atomify with less cause the following error was thrown:

```
File written to .tmp/bundle.css

/dev/project1/node_modules/atomify/lib/cli.js:42
          resourcepaths.cssEntry  = [path.join(process.cwd(), args.css.entry)]
                         ^
TypeError: Cannot set property 'cssEntry' of undefined
    at doWatchWriteServerstart (/dev/project1/node_modules/atomify/lib/cli.js:42:35)
    at callbackWrapper (/dev/project1/node_modules/atomify/node_modules/atomify-css/index.js:55:11)
    at complete (/dev/project1/node_modules/atomify/node_modules/atomify-css/index.js:63:5)
    at /dev/project1/node_modules/atomify/node_modules/atomify-css/less.js:22:35
    at process._tickCallback (node.js:419:13)
```

As you can see the file was written but the atomify server didn't start cause of this error.

My atomify config in package.json looks like this
```
"atomify": {
    "server": {
      "lr": {
        "port": 9000
      },
      "port": 4000,
      "html": "app/index.html",
      "spaMode": true
    },
    "js": {
      "entry": "app/app.module.js",
      "alias": "/bundle.js",
      "output": ".tmp/bundle.js",
      "debug": true
    },
    "css": {
      "entry": "app/index.less",
      "alias": "/bundle.css",
      "output": ".tmp/bundle.css",
      "debug": true,
      "assets": {
        "dest": "dist/assets",
        "prefix": "assets/"
      }
    }
}
```
I found the following in the changelog:
`## 7.0.0`
` * change: removed undocumented APIs around resourcepaths`

And looking at the code I found a leftover of resourcepaths which is not needed anymore. That's why I removed it and now everything works fine.